### PR TITLE
examples/x86_64-mont: annotate vector indices with #! $reg = value.

### DIFF
--- a/examples/x86_64-mont/x86_64-mont.pl
+++ b/examples/x86_64-mont/x86_64-mont.pl
@@ -161,7 +161,7 @@ $code.=<<___				if ($UNROLL==1);
 .align	16
 .L1st:
 ___
-for (my $inner=0; $inner<$UNROLL; $inner++) {
+for (my $inner=0; $inner<($UNROLL==1 ? 1 : $UNROLL-1); $inner++) {
 $code.=<<___				if ($inner || $UNROLL==1);
 	add	%rax,$hi1
 	mov	($ap,$j,8),%rax
@@ -242,7 +242,7 @@ $code.=<<___				if ($UNROLL==1);
 .align	16
 .Linner:
 ___
-for (my $inner=0; $inner<$UNROLL; $inner++) {
+for (my $inner=0; $inner<($UNROLL==1 ? 1 : $UNROLL-1); $inner++) {
 $code.=<<___				if ($inner || $UNROLL==1);
 	add	%rax,$hi1
 	mov	($ap,$j,8),%rax


### PR DESCRIPTION
This also fixes kind of a "brown-bag" bug. There was mismatch in how $UNROLL was interpreted for inner and outer loop unrolling, which became apparent when when I was debugging annotated output...