### PR TITLE
Add x86_64 per-instruction execution trace collector.

### DIFF
--- a/examples/itrace-x86_64.py
+++ b/examples/itrace-x86_64.py
@@ -50,8 +50,8 @@ def trace():
         mnemonic = insn["asm"]
         b = branch.search(mnemonic)
         if b:                               # skip over flow control
-            print("\t#{0:s}".format(mnemonic))
             gdb.execute("stepi", to_string=True)
+            print("\t#" + mnemonic)
             if b.group(1) == "call":        # calls are handled recursively
                 trace()
             elif b.group(1) == "ret":
@@ -80,7 +80,7 @@ def trace():
 def header(function):
     frame = gdb.newest_frame()
 
-    print("{0:s}:".format(function))
+    print(function + ":")
     for reg in ("rdi", "rsi", "rdx", "rcx", "r8", "r9"):
         print("# %{0:3s} = 0x{1:x}".format(reg, int(frame.read_register(reg))))
 
@@ -95,7 +95,7 @@ function = os.environ["TRACE_FUNCTION"]
 # quirk: even though gdb.Breakpoint is documented to have pending attribute
 # it didn't work for me :-(
 s = gdb.execute("break " + function, to_string=True)
-if re.search("not defined", s):
+if re.search("not defined", s):             # symbol was not found
     print(s.split("\n")[0])
     sys.exit(-1)
 

--- a/examples/itrace-x86_64.py
+++ b/examples/itrace-x86_64.py
@@ -15,7 +15,7 @@ try:
     gdb             # gdb module is pre-loaded in gdb context
 except NameError:
     if len(sys.argv) < 3 or not os.access(sys.argv[1], os.X_OK):
-        print("Usage: {0:s} executable funtion [file]".format(sys.argv[0]))
+        print("Usage: {0:s} executable function [file]".format(sys.argv[0]))
         sys.exit(-1)
 
     # pass arguments through environment
@@ -25,9 +25,9 @@ except NameError:
 
     try:
         os.execlpe("gdb", "gdb", "--batch",
-	                         "--command=" + sys.argv[0],
-				 sys.argv[1],
-		   os.environ)
+                                 "--command=" + sys.argv[0],
+                                 sys.argv[1],
+                   os.environ)
     except OSError as e :
         sys.exit(e.errno)
     sys.exit(-1)

--- a/examples/itrace-x86_64.py
+++ b/examples/itrace-x86_64.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+#
+# This script utilizes python-enabled gdb on your $PATH to collect
+# per-instruction execution trace for first invocation of named
+# function [and its descendants]. It also annotates instructions
+# that reference memory [as well as "lea"] with actual effective
+# addresses...
+#
+#                                           <appro@openssl.org>
+
+import os
+import sys
+
+try:
+    gdb             # gdb module is pre-loaded in gdb context
+except NameError:
+    if len(sys.argv) < 3 or not os.access(sys.argv[1], os.X_OK):
+        print("Usage: {0:s} executable funtion [file]".format(sys.argv[0]))
+        sys.exit(-1)
+
+    # pass arguments through environment
+    os.environ["TRACE_FUNCTION"] = sys.argv[2]
+    os.environ["TRACE_OUTFILE"] = ""
+    if len(sys.argv) > 3 : os.environ["TRACE_OUTFILE"] = sys.argv[3]
+
+    try:
+        os.execlpe("gdb", "gdb", "--batch",
+	                         "--command=" + sys.argv[0],
+				 sys.argv[1],
+		   os.environ)
+    except OSError as e :
+        sys.exit(e.errno)
+    sys.exit(-1)
+
+##############################################################################
+# this part is executed in gdb context and that's where it all happens...
+
+import re
+
+# some globals
+branch = re.compile(r'^(?:repz\s+)?(j\w*|call|ret)q?')
+eapattern = re.compile(r'(-?(?:0x)?[0-9a-f]+)?\(%([a-z0-9]+)'
+                        '(?:,%([a-z0-9]+),([1248]))?\)')
+function = os.environ["TRACE_FUNCTION"]
+outfile = os.environ["TRACE_OUTFILE"]
+
+def trace():
+    frame = gdb.newest_frame()
+    arch = frame.architecture()
+
+    while(frame.is_valid()):
+        insn = arch.disassemble(frame.pc(), count=1)[0]
+        mnemonic = insn["asm"]
+        b = branch.search(mnemonic)
+        if b:                               # skip over flow control
+            print("\t#{0:s}".format(mnemonic))
+            gdb.execute("stepi", to_string=True)
+            if b.group(1) == "call":        # calls are handled recursively
+                trace()
+            elif b.group(1) == "ret":
+                return
+            elif not frame.is_valid():      # inter-procedure branches
+                frame = gdb.newest_frame()
+                arch = frame.architecture()
+        else:
+            ea = eapattern.search(mnemonic)
+            if ea:
+                addr = 0
+                if ea.group(1) : addr = int(ea.group(1), 0)
+                if ea.group(2) == "rip" : addr += insn["length"]
+                addr += int(frame.read_register(ea.group(2)))
+                if ea.group(3):
+                    addr += int(frame.read_register(ea.group(3))) * \
+                            int(ea.group(4))
+                print("\t{0:48s}#ea = 0x{1:x}".format(mnemonic, int(addr)))
+            else:
+                print("\t{0:s}".format(mnemonic))
+            gdb.execute("stepi", to_string=True)
+
+    gdb.execute("stepi", to_string=True)    # step over retq
+    return
+
+def header(function):
+    frame = gdb.newest_frame()
+
+    print("{0:s}:".format(function))
+    for reg in ("rdi", "rsi", "rdx", "rcx", "r8", "r9"):
+        print("# %{0:3s} = 0x{1:x}".format(reg, int(frame.read_register(reg))))
+
+    return
+
+# "main"
+if outfile : sys.stdout = open(outfile, "w")
+
+# quirk: even though gdb.Breakpoint is documented to have pending attribute
+# it didn't work for me :-(
+s = gdb.execute("break " + function, to_string=True)
+if re.search("not defined", s):
+    print(s.split("\n")[0])
+    sys.exit(-1)
+
+gdb.execute("run", to_string=True)
+
+header(function)
+trace()
+
+gdb.execute("delete breakpoints", to_string=True)


### PR DESCRIPTION
This script utilizes python-enabled gdb on your $PATH to collect
per-instruction execution trace for first invocation of named
function [and its descendants]. It also annotates instructions
that reference memory [as well as "lea"] with actual effective
addresses...